### PR TITLE
feat: add optional parent ID for subaccount

### DIFF
--- a/templates/generate_main_btp.tm.hcl
+++ b/templates/generate_main_btp.tm.hcl
@@ -35,6 +35,7 @@ generate_hcl "_terramate_generated_main_btp.tf" {
       name      = local.subaccount_name
       subdomain = local.subaccount_subdomain
       region    = lower(var.region)
+      parent_id = var.parent_id
     }
 
     # ------------------------------------------------------------------------------------------------------

--- a/templates/generate_variables_btp.tm.hcl
+++ b/templates/generate_variables_btp.tm.hcl
@@ -37,6 +37,12 @@ generate_hcl "_terramate_generated_variables.tf" {
       default     = true
     }
 
+    variable "parent_id" {
+      type        = string
+      description = "ID of the parent account for the subaccount."
+      default     = ""
+    }
+
     variable "subaccount_subdomain_prefix" {
       type        = string
       description = "The prefix for the SAP BTP subaccount subdomain."


### PR DESCRIPTION
Add optiopnal parameter for parent of subaccount to enable the creation of the subaccount underneath a parent directory.
